### PR TITLE
Fix Firefox XML Parsing Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.0
 
 - Halt connections after sending responses. PR #1 by [@lucasmazza](https://github.com/lucasmazza)
+- Fix Firefox XML Parsing Error. PR #2 by [@tombruijn](https://github.com/tombruijn)
 
 ## 0.1.0
 

--- a/lib/appsignal_js_plug.ex
+++ b/lib/appsignal_js_plug.ex
@@ -64,6 +64,7 @@ if appsignal.plug? do
       |> complete_transaction(conn)
 
       conn
+      |> put_resp_header("content-type", "text/html; charset=utf-8")
       |> send_resp(200, "")
       |> halt
     end

--- a/test/appsignal_js_plug_test.exs
+++ b/test/appsignal_js_plug_test.exs
@@ -64,6 +64,7 @@ defmodule Appsignal.JSPlugTest do
     |> send_request
 
     assert conn.halted
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     assert FakeTransaction.action == nil
     assert FakeTransaction.sample_data == %{
       "environment" => %{
@@ -109,6 +110,7 @@ defmodule Appsignal.JSPlugTest do
     |> send_request
 
     assert conn.halted
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     assert FakeTransaction.action == nil
     assert FakeTransaction.sample_data == %{
       "environment" => %{
@@ -146,6 +148,7 @@ defmodule Appsignal.JSPlugTest do
     |> send_request
 
     assert conn.halted
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     assert FakeTransaction.action == nil
     assert FakeTransaction.sample_data == %{
       "environment" => %{
@@ -182,6 +185,7 @@ defmodule Appsignal.JSPlugTest do
     |> send_request
 
     assert conn.halted
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     assert FakeTransaction.action == nil
     assert FakeTransaction.sample_data == %{
       "environment" => %{
@@ -227,6 +231,7 @@ defmodule Appsignal.JSPlugTest do
       |> send_request
 
       assert conn.halted
+      assert Plug.Conn.get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
       assert FakeTransaction.sample_data == %{
         "environment" => %{
           "agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6)",


### PR DESCRIPTION
On Firefox the empty response from the plug would log an error in the
web console.

```
XML Parsing Error: no root element found
Location: http://localhost:4000/appsignal_error_catcher
Line Number 1, Column 1:
```

By adding a header that tells the browser the response is plain text, it
will not try to parse the (empty) response as an XML document.