### PR TITLE
Implement parameter filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Halt connections after sending responses. PR #1 by [@lucasmazza](https://github.com/lucasmazza)
 - Fix Firefox XML Parsing Error. PR #2 by [@tombruijn](https://github.com/tombruijn)
+- Add parameter filtering. PR #3 by [@tombruijn](https://github.com/tombruijn)
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ Then run `mix deps.get`.
 
 ## Configuration
 
+### `filter_parameters`
+
+This package listens to the AppSignal for Elixir [`filter_parameters`
+configuration option]. If this option is set, all parameters values matching a
+key name from the configuration will be replaced with `[FILTERED]`.
+
+```elixir
+# config/appsignal.exs
+config :appsignal, :config, filter_parameters: ["password"]
+```
+
+### `skip_session_data`
+
 This package listens to the AppSignal for Elixir [`skip_session_data`
 configuration option]. If this option is set to `true`, no session data will be
 added to the JavaScript errors.
@@ -84,3 +97,4 @@ the MIT License. Check the [LICENSE](LICENSE) file for more information.
 [installation guide]: https://docs.appsignal.com/elixir/installation.html
 [Front-end error handling]: https://docs.appsignal.com/front-end/error-handling.html
 [`skip_session_data` configuration option]: https://docs.appsignal.com/elixir/configuration/options.html#appsignal_skip_session_data-skip_session_data
+[`filter_parameters` configuration option]: https://docs.appsignal.com/elixir/configuration/parameter-filtering.html

--- a/lib/appsignal_js_plug.ex
+++ b/lib/appsignal_js_plug.ex
@@ -102,7 +102,11 @@ if appsignal.plug? do
       # Only set params when available
       case Map.fetch(conn.params, "params") do
         {:ok, params} ->
-          @transaction.set_sample_data(transaction, "params", params)
+          @transaction.set_sample_data(
+            transaction,
+            "params",
+            Appsignal.Utils.ParamsFilter.filter_values(params)
+          )
         :error -> transaction
       end
     end


### PR DESCRIPTION
Leverage the AppSignal parameter filtering for the JSPlug. Any
parameters send to the plug with the `params` JSON key will be filtered
using the configuration used by the AppSignal package.

This ensures that apps don't accidentally send (user) sensitive data to
AppSignal.